### PR TITLE
Setup local env for conda usage

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,6 @@ data
 .Rproj.user
 .Rhistory
 .idea
+
+.env.local
+notebooks/**/.ipynb_checkpoints

--- a/README.md
+++ b/README.md
@@ -1,3 +1,47 @@
 # CSE6250-project
 
 This is the repository for 2019 Fall CSE6250 project.
+
+# Usage
+
+Generate Plots & CSV of Channels and Labels
+
+> `python program/eda.py`
+
+Transform Data
+
+> `python program/data_prep_v0.py`
+
+Train Model
+
+> `python program/model_v0.py`
+
+# Description of Parameters & Labels
+
+...
+
+# Conda
+
+## tldr;
+
+> `conda env create -f environment.yml`
+
+> `conda activate cse6250-project-sleep`
+
+## setup steps:
+
+environment originally created via:
+
+> `conda create --name cse6250-project-sleep`
+
+activate the new environment:
+
+> `conda activate cse6250-project-sleep`
+
+copied a base environment.yml and then installed packages individually:
+
+> `conda install <package>`
+
+now, environment can be installed from `environment.yml` via
+
+> `conda env create -f environment.yml`

--- a/environment.yml
+++ b/environment.yml
@@ -16,6 +16,7 @@ dependencies:
   - scipy
   - pandas
   - matplotlib==3.1.0
+  - nb_conda_kernels
   - pytest
   - pip
   - pip:

--- a/environment.yml
+++ b/environment.yml
@@ -1,0 +1,22 @@
+name: cse6250-project-sleep
+channels:
+  - conda-forge
+  - pytorch
+  - defaults
+dependencies:
+  - mne
+  - seaborn
+  - lightgbm
+  - python=3.6
+  - pytorch>=1.3.0
+  - torchvision
+  # - cudatoolkit>=9.2    # mac OS users should comment out this (for CPU only) or build from the source
+  - scikit-learn
+  - numpy
+  - scipy
+  - pandas
+  - matplotlib==3.1.0
+  - pytest
+  - pip
+  - pip:
+      - delayed-assert

--- a/notebooks/Exploratory Analysis.ipynb
+++ b/notebooks/Exploratory Analysis.ipynb
@@ -1,0 +1,42 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import numpy as np\n",
+    "import mne"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.7.4"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}


### PR DESCRIPTION
- updated readme with some guidelines on using conda
- nb_conda_kernels should be installed as part of environments.yml
   - if it does not, try: activating `cse6250-project-sleep` then running `conda install -n cse6250-project-sleep nb_conda_kernels`
- added example notebook to make sure it works.
  - im thinking we can put notebooks under `./notebooks/<username>/our_notebooks` if desired
  - and we can put notebooks under `./notebooks/` directly (again, if we desire)